### PR TITLE
Remove "flyer download link" from package bundles

### DIFF
--- a/migrations/20230109221118-package-bundle-remove-link.js
+++ b/migrations/20230109221118-package-bundle-remove-link.js
@@ -1,0 +1,22 @@
+export default {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.sequelize.transaction((t) => {
+      return Promise.all([
+        queryInterface.removeColumn('PackageBundles', 'flyerDownloadLink', { transaction: t }),
+      ]);
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    return Promise.all([
+      queryInterface.addColumn(
+        'PackageBundles',
+        'flyerDownloadLink',
+        {
+          type: Sequelize.DataTypes.STRING,
+        },
+        { transaction: t }
+      ),
+    ]);
+  },
+};

--- a/models/package-bundle.js
+++ b/models/package-bundle.js
@@ -8,7 +8,6 @@ const createModel = (sequelize, DataTypes) => {
         notEmpty: true,
       },
     },
-    flyerDownloadLink: DataTypes.STRING,
     fileUrl: DataTypes.STRING,
     specialText: DataTypes.STRING,
     prices: DataTypes.STRING,

--- a/resources/package-bundle.js
+++ b/resources/package-bundle.js
@@ -7,7 +7,6 @@ export default (model) => {
     attributes: {
       displayOrder: model.displayOrder,
       title: model.title,
-      flyerDownloadLink: model.flyerDownloadLink,
       fileUrl: model.fileUrl,
       specialText: model.specialText,
       prices: format(model.prices),


### PR DESCRIPTION
The flyer download link column for the Package Bundles was deprecated. Removing them from code so it doesn't cause confusion.