### PR TITLE
Fix boolean columns on Specials

### DIFF
--- a/migrations/20231118024744-special-default-values.js
+++ b/migrations/20231118024744-special-default-values.js
@@ -1,0 +1,59 @@
+export default {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.sequelize.transaction((t) => {
+      return Promise.all([
+        queryInterface.sequelize.query(
+          'UPDATE public."Specials" SET "isSoldOut"=false WHERE "isSoldOut" IS NULL',
+          { transaction: t }
+        ),
+        queryInterface.sequelize.query(
+          'UPDATE public."Specials" SET "isHidden"=false WHERE "isHidden" IS NULL',
+          { transaction: t }
+        ),
+        queryInterface.changeColumn(
+          'Specials',
+          'isSoldOut',
+          {
+            type: Sequelize.BOOLEAN,
+            allowNull: false,
+            defaultValue: false,
+          },
+          { transaction: t }
+        ),
+        queryInterface.changeColumn(
+          'Specials',
+          'isHidden',
+          {
+            type: Sequelize.BOOLEAN,
+            allowNull: false,
+            defaultValue: false,
+          },
+          { transaction: t }
+        ),
+      ]);
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.sequelize.transaction((t) => {
+      return Promise.all([
+        queryInterface.changeColumn(
+          'Specials',
+          'isSoldOut',
+          {
+            type: Sequelize.BOOLEAN,
+          },
+          { transaction: t }
+        ),
+        queryInterface.changeColumn(
+          'Specials',
+          'isHidden',
+          {
+            type: Sequelize.BOOLEAN,
+          },
+          { transaction: t }
+        ),
+      ]);
+    });
+  },
+};


### PR DESCRIPTION
The `isHidden` and `isSoldOut` columns defaulted to `NULL`. When adding a new Special, if both those checkbox fields were unchecked, it wasn't passing those attributes, which then made them `NULL` in the database. The query to return Specials on the home page was only getting ones where the values were `false`, so it wouldn't show newly added Specials.