### PR TITLE
Remove featured from grab and go

### DIFF
--- a/migrations/20241214181331-grab-go-remove-featured.js
+++ b/migrations/20241214181331-grab-go-remove-featured.js
@@ -1,0 +1,25 @@
+export default {
+  async up(queryInterface, Sequelize) {
+    return await queryInterface.sequelize.transaction((t) => {
+      return Promise.all([
+        queryInterface.removeColumn('GrabAndGos', 'featured', { transaction: t }),
+      ]);
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.sequelize.transaction((t) => {
+      return Promise.all([
+        queryInterface.addColumn(
+          'GrabAndGos',
+          'featured',
+          {
+            type: Sequelize.DataTypes.BOOLEAN,
+            defaultValue: false,
+          },
+          { transaction: t }
+        ),
+      ]);
+    });
+  },
+};

--- a/models/grab-and-go.js
+++ b/models/grab-and-go.js
@@ -11,7 +11,6 @@ module.exports = (sequelize) => {
     },
     description: Sequelize.STRING,
     imageUrl: Sequelize.STRING,
-    featured: Sequelize.BOOLEAN,
     isSoldOut: Sequelize.BOOLEAN,
   });
 

--- a/resources/grab-and-go.js
+++ b/resources/grab-and-go.js
@@ -8,7 +8,6 @@ export default (model) => {
       title: model.title,
       description: model.description,
       imageUrl: model.imageUrl,
-      featured: model.featured,
       isSoldOut: model.isSoldOut,
       createdAt: model.createdAt,
       updatedAt: model.updatedAt,

--- a/routes/grab-and-go.js
+++ b/routes/grab-and-go.js
@@ -5,17 +5,7 @@ import { deleteUploadedFile } from '../utilities/file';
 const router = new Router();
 
 router.get('/', async (ctx) => {
-  const featured = ctx.query['filter[featured]'];
-  let where = {};
-
-  if (featured !== undefined) {
-    where.featured = true;
-  }
-
-  let items = await ctx.app.db.GrabAndGo.findAll({
-    where,
-    order: [['title', 'asc']],
-  });
+  let items = await ctx.app.db.GrabAndGo.findAll({ order: [['title', 'asc']] });
 
   ctx.body = ctx.app.serialize('grab-and-go', items);
 });


### PR DESCRIPTION
There's no reason to have a separate `featured` and `isSoldOut` on the Grab and Go items. Removing `featured` and if it's not `isSoldOut`, then it shows on "Today's Items". If it is, then it shows under "Common Items" and shows the "Sold Out" banner.