### PR TITLE
Add holiday grab and go item

### DIFF
--- a/src/db/migrations/20251120231501-grab-go-is-holiday.js
+++ b/src/db/migrations/20251120231501-grab-go-is-holiday.js
@@ -1,0 +1,28 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.sequelize.transaction((t) => {
+      return Promise.all([
+        queryInterface.addColumn(
+          'GrabAndGos',
+          'isHoliday',
+          {
+            type: Sequelize.DataTypes.BOOLEAN,
+            defaultValue: false,
+          },
+          { transaction: t }
+        ),
+      ]);
+    });
+  },
+
+  async down(queryInterface) {
+    return await queryInterface.sequelize.transaction((t) => {
+      return Promise.all([
+        queryInterface.removeColumn('GrabAndGos', 'isHoliday', { transaction: t }),
+      ]);
+    });
+  },
+};

--- a/src/db/models/grab-and-go.js
+++ b/src/db/models/grab-and-go.js
@@ -13,6 +13,7 @@ export default (sequelize) => {
     description: Sequelize.STRING,
     imageUrl: Sequelize.STRING,
     inStock: Sequelize.BOOLEAN,
+    isHoliday: Sequelize.BOOLEAN,
   });
 
   return GrabAndGo;

--- a/src/resources/grab-and-go.js
+++ b/src/resources/grab-and-go.js
@@ -10,6 +10,7 @@ export default (model) => {
       description: model.description,
       imageUrl: model.imageUrl,
       inStock: model.inStock,
+      isHoliday: model.isHoliday,
       createdAt: model.createdAt,
       updatedAt: model.updatedAt,
     },

--- a/src/routes/grab-and-go.js
+++ b/src/routes/grab-and-go.js
@@ -5,10 +5,15 @@ const router = new Router();
 
 router.get('/', async (ctx) => {
   const inStock = ctx.query['filter[inStock]'];
+  const isHoliday = ctx.query['filter[isHoliday]'];
   let where = {};
 
   if (inStock !== undefined) {
-    where.inStock = true;
+    where.inStock = inStock === 'true';
+  }
+
+  if (isHoliday !== undefined) {
+    where.isHoliday = isHoliday === 'true';
   }
 
   let items = await ctx.app.db.GrabAndGo.findAll({


### PR DESCRIPTION
This adds a new "is holiday" option to the Grab and Go items so that if marked as "is holiday", it will be grouped in a new section at the top of the Grab and Go page. If there are no items marked as "is holiday", then the section won't appear.